### PR TITLE
localization and dep changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,19 +2,32 @@
 
 
 [[projects]]
+  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  pruneopts = "UT"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:5e4935cc8119106bd57106538ef40f98a69b801e43c98b6bba24354604d5883f"
+  name = "github.com/graph-gophers/dataloader"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "78139374585c29dcb97b8f33089ed11959e4be59"
+  version = "v5"
+
+[[projects]]
   branch = "master"
+  digest = "1:e91284f7f7d051024548995a7d51ad29dee7c9bc07ef28410a8a71c4668d34f4"
   name = "github.com/graph-gophers/graphql-go"
   packages = [
     ".",
@@ -30,12 +43,13 @@
     "internal/validation",
     "introspection",
     "log",
-    "trace"
+    "trace",
   ]
-  revision = "31656de753ad9b2355bd5c978e329762bb3a356c"
+  pruneopts = "UT"
+  revision = "0079757a4d9612f5674f8f9996e2350e1259ff1b"
 
 [[projects]]
-  branch = "master"
+  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -47,128 +61,165 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  pruneopts = "UT"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d8715388cdd077d4b5e477e92e93e8c2c16c5f8cdc1f79b0ef2616ef8ea09f9f"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
-    "reflectx"
+    "reflectx",
   ]
-  revision = "cf35089a197953c69420c8d0cecda90809764b1d"
+  pruneopts = "UT"
+  revision = "82935fac6c1a317907c8f43ed3f7f85ea844a78b"
 
 [[projects]]
+  digest = "1:0015060922f1b2e04469224e2ed82f0a67abbfee9a0a91852cf4980b91bf11d6"
   name = "github.com/jteeuwen/go-bindata"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bbd0c6e271208dce66d8fda4bc536453cd27fc4a"
   version = "v3.0.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:7cefc4f7f6a411c2598d3344563e4d23fd4e4d88fd1591831fe39cccff41ad28"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid"
+    "oid",
   ]
-  revision = "88edab0803230a3898347e77b474f8c1820a1f20"
+  pruneopts = "UT"
+  revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
 
 [[projects]]
+  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
+  pruneopts = "UT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+  pruneopts = "UT"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
+  digest = "1:5b3b29ce0e569f62935d9541dff2e16cc09df981ebde48e82259076a73a3d0c7"
   name = "github.com/op/go-logging"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b2cb9fa56473e98db8caba80237377e83fe44db5"
   version = "v1"
 
 [[projects]]
+  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
   ]
+  pruneopts = "UT"
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
-
-[[projects]]
-  name = "github.com/rs/xid"
-  packages = ["."]
-  revision = "02dd45c33376f85d1064355dc790dcc4850596b1"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem"
-  ]
-  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
-  version = "v1.0.2"
-
-[[projects]]
-  name = "github.com/spf13/cast"
-  packages = ["."]
-  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  pruneopts = "UT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/spf13/jwalterweatherman"
+  digest = "1:2e76a73cb51f42d63a2a1a85b3dc5731fd4faf6821b434bd0ef2c099186031d6"
+  name = "github.com/rs/xid"
   packages = ["."]
-  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+  pruneopts = "UT"
+  revision = "15d26544def341f036c5f8dca987a4cbe575032c"
+  version = "v1.2.1"
 
 [[projects]]
-  name = "github.com/spf13/pflag"
+  digest = "1:d707dbc1330c0ed177d4642d6ae102d5e2c847ebd0eb84562d0dc4f024531cfc"
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = "UT"
+  revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
+  name = "github.com/spf13/cast"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  pruneopts = "UT"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
+  digest = "1:de37e343c64582d7026bf8ab6ac5b22a72eac54f3a57020db31524affed9f423"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = "UT"
   revision = "master"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ecf2a49df33be51e757d0033d5d51d5f784f35f68e5a38f797b2d3f03357d71"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
-    "blowfish"
+    "blowfish",
   ]
-  revision = "85f98707c97e11569271e4d9b3d397e079c4f4d0"
+  pruneopts = "UT"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   branch = "master"
+  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "d25186b37f34ebdbbea8f488ef055638dfab272d"
+  pruneopts = "UT"
+  revision = "927f97764cc334a6575f4b7a1584a147864d5723"
 
 [[projects]]
   branch = "master"
+  digest = "1:5b7594f7c43cb5fc8f31c3f4a9f6a61ee798dbd5fcb36b70cb3d4780aad4c509"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  pruneopts = "UT"
+  revision = "9a3f9b0469bbc6b8802087ae5c0af9f61502de01"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -176,26 +227,35 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  name = "gopkg.in/nicksrandall/dataloader.v5"
-  packages = ["."]
-  revision = "78139374585c29dcb97b8f33089ed11959e4be59"
-  version = "v5"
-
-[[projects]]
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  pruneopts = "UT"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "33d6773b6749d4e62fbc691656b684cf293dd22054d3907c632b2c67a2680934"
+  input-imports = [
+    "github.com/dgrijalva/jwt-go",
+    "github.com/graph-gophers/dataloader",
+    "github.com/graph-gophers/graphql-go",
+    "github.com/graph-gophers/graphql-go/gqltesting",
+    "github.com/jmoiron/sqlx",
+    "github.com/jteeuwen/go-bindata",
+    "github.com/lib/pq",
+    "github.com/op/go-logging",
+    "github.com/rs/xid",
+    "github.com/spf13/viper",
+    "golang.org/x/crypto/bcrypt",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,28 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
 required = ["github.com/jteeuwen/go-bindata"]
 
 [[constraint]]
@@ -32,6 +7,10 @@ required = ["github.com/jteeuwen/go-bindata"]
 [[constraint]]
   branch = "master"
   name = "github.com/graph-gophers/graphql-go"
+
+[[constraint]]
+  name = "github.com/graph-gophers/dataloader"
+  version = "5.0.0"
 
 [[constraint]]
   branch = "master"
@@ -56,14 +35,6 @@ required = ["github.com/jteeuwen/go-bindata"]
 [[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"
-
-[[constraint]]
-  name = "gopkg.in/nicksrandall/dataloader.v5"
-  version = "5.0.0"
 
 [prune]
   go-tests = true

--- a/context/configuration.go
+++ b/context/configuration.go
@@ -1,9 +1,10 @@
 package context
 
 import (
-	"github.com/spf13/viper"
 	"log"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 type Config struct {

--- a/context/db.go
+++ b/context/db.go
@@ -2,10 +2,11 @@ package context
 
 import (
 	"fmt"
-	"github.com/jmoiron/sqlx"
-	_ "github.com/lib/pq"
 	"log"
 	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
 )
 
 func OpenDB(config *Config) (*sqlx.DB, error) {

--- a/handler/auth.go
+++ b/handler/auth.go
@@ -1,18 +1,20 @@
 package handler
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	gcontext "github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/OscarYuen/go-graphql-starter/service"
-	jwt "github.com/dgrijalva/jwt-go"
-	"golang.org/x/net/context"
 	"log"
 	"net"
 	"net/http"
 	"strings"
+
+	gcontext "go-graphql-starter/context"
+	model "go-graphql-starter/model"
+	service "go-graphql-starter/service"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 func Authenticate(h http.Handler) http.Handler {

--- a/handler/context.go
+++ b/handler/context.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"net/http"
 )
 

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"encoding/json"
-	"github.com/OscarYuen/go-graphql-starter/loader"
-	"github.com/graph-gophers/graphql-go"
 	"net/http"
+
+	loader "go-graphql-starter/loader"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 type GraphQL struct {

--- a/handler/logger.go
+++ b/handler/logger.go
@@ -2,9 +2,10 @@ package handler
 
 import (
 	"bytes"
-	"github.com/op/go-logging"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/op/go-logging"
 )
 
 type LoggerHandler struct {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,9 +1,10 @@
 package loader
 
 import (
+	"context"
 	"fmt"
-	"golang.org/x/net/context"
-	"gopkg.in/nicksrandall/dataloader.v5"
+
+	"github.com/graph-gophers/dataloader"
 )
 
 type key string

--- a/loader/user.go
+++ b/loader/user.go
@@ -1,12 +1,14 @@
 package loader
 
 import (
+	"context"
 	"fmt"
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/OscarYuen/go-graphql-starter/service"
-	"golang.org/x/net/context"
-	"gopkg.in/nicksrandall/dataloader.v5"
 	"sync"
+
+	model "go-graphql-starter/model"
+	service "go-graphql-starter/service"
+
+	"github.com/graph-gophers/dataloader"
 )
 
 // FilmLoader contains the client required to load film resources.

--- a/model/user.go
+++ b/model/user.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"golang.org/x/crypto/bcrypt"
 	"log"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 type User struct {

--- a/resolver/page_info_resolver.go
+++ b/resolver/page_info_resolver.go
@@ -1,6 +1,6 @@
 package resolver
 
-import "github.com/graph-gophers/graphql-go"
+import graphql "github.com/graph-gophers/graphql-go"
 
 type pageInfoResolver struct {
 	startCursor graphql.ID

--- a/resolver/role_resolver.go
+++ b/resolver/role_resolver.go
@@ -1,8 +1,9 @@
 package resolver
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/graph-gophers/graphql-go"
+	model "go-graphql-starter/model"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 type roleResolver struct {

--- a/resolver/user_mutation.go
+++ b/resolver/user_mutation.go
@@ -1,10 +1,12 @@
 package resolver
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/OscarYuen/go-graphql-starter/service"
+	"context"
+
+	model "go-graphql-starter/model"
+	service "go-graphql-starter/service"
+
 	"github.com/op/go-logging"
-	"golang.org/x/net/context"
 )
 
 func (r *Resolver) CreateUser(ctx context.Context, args *struct {

--- a/resolver/user_query.go
+++ b/resolver/user_query.go
@@ -1,12 +1,14 @@
 package resolver
 
 import (
+	"context"
 	"errors"
-	gcontext "github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/loader"
-	"github.com/OscarYuen/go-graphql-starter/service"
+
+	gcontext "go-graphql-starter/context"
+	loader "go-graphql-starter/loader"
+	service "go-graphql-starter/service"
+
 	"github.com/op/go-logging"
-	"golang.org/x/net/context"
 )
 
 func (r *Resolver) User(ctx context.Context, args struct {

--- a/resolver/user_query_test.go
+++ b/resolver/user_query_test.go
@@ -1,14 +1,16 @@
 package resolver
 
 import (
-	gcontext "github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/schema"
-	"github.com/OscarYuen/go-graphql-starter/service"
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/gqltesting"
-	"golang.org/x/net/context"
+	"context"
 	"log"
 	"testing"
+
+	gcontext "go-graphql-starter/context"
+	schema "go-graphql-starter/schema"
+	service "go-graphql-starter/service"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/gqltesting"
 )
 
 var (

--- a/resolver/user_resolver.go
+++ b/resolver/user_resolver.go
@@ -1,9 +1,11 @@
 package resolver
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/model"
-	graphql "github.com/graph-gophers/graphql-go"
 	"time"
+
+	model "go-graphql-starter/model"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 type userResolver struct {

--- a/resolver/users_connection_resolver.go
+++ b/resolver/users_connection_resolver.go
@@ -1,8 +1,8 @@
 package resolver
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/OscarYuen/go-graphql-starter/service"
+	model "go-graphql-starter/model"
+	service "go-graphql-starter/service"
 )
 
 type usersConnectionResolver struct {

--- a/resolver/users_edge_resolver.go
+++ b/resolver/users_edge_resolver.go
@@ -1,8 +1,9 @@
 package resolver
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/graph-gophers/graphql-go"
+	model "go-graphql-starter/model"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 type usersEdgeResolver struct {

--- a/server.go
+++ b/server.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	gcontext "github.com/OscarYuen/go-graphql-starter/context"
-	h "github.com/OscarYuen/go-graphql-starter/handler"
-	"github.com/OscarYuen/go-graphql-starter/resolver"
-	"github.com/OscarYuen/go-graphql-starter/schema"
-	"github.com/OscarYuen/go-graphql-starter/service"
+	"context"
 	"log"
 	"net/http"
 
-	"github.com/OscarYuen/go-graphql-starter/loader"
+	gcontext "go-graphql-starter/context"
+	h "go-graphql-starter/handler"
+	loader "go-graphql-starter/loader"
+	resolver "go-graphql-starter/resolver"
+	schema "go-graphql-starter/schema"
+	service "go-graphql-starter/service"
+
 	graphql "github.com/graph-gophers/graphql-go"
-	"golang.org/x/net/context"
 )
 
 func main() {

--- a/service/auth_service.go
+++ b/service/auth_service.go
@@ -3,11 +3,13 @@ package service
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/model"
+	"time"
+
+	gcontext "go-graphql-starter/context"
+	model "go-graphql-starter/model"
+
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/op/go-logging"
-	"time"
 )
 
 type AuthService struct {
@@ -17,7 +19,7 @@ type AuthService struct {
 	log                 *logging.Logger
 }
 
-func NewAuthService(config *context.Config, log *logging.Logger) *AuthService {
+func NewAuthService(config *gcontext.Config, log *logging.Logger) *AuthService {
 	return &AuthService{&config.AppName, &config.JWTSecret, &config.JWTExpireIn, log}
 }
 

--- a/service/auth_service_test.go
+++ b/service/auth_service_test.go
@@ -1,9 +1,10 @@
 package service
 
 import (
-	gcontext "github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/model"
 	"testing"
+	
+	gcontext "go-graphql-starter/context"
+	model "go-graphql-starter/model"
 )
 
 var (

--- a/service/helper.go
+++ b/service/helper.go
@@ -3,8 +3,9 @@ package service
 import (
 	"encoding/base64"
 	"fmt"
-	graphql "github.com/graph-gophers/graphql-go"
 	"strings"
+
+	graphql "github.com/graph-gophers/graphql-go"
 )
 
 func EncodeCursor(i *string) graphql.ID {

--- a/service/log_service.go
+++ b/service/log_service.go
@@ -1,12 +1,14 @@
 package service
 
 import (
-	"github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/op/go-logging"
 	"os"
+
+	gcontext "go-graphql-starter/context"
+
+	"github.com/op/go-logging"
 )
 
-func NewLogger(config *context.Config) *logging.Logger {
+func NewLogger(config *gcontext.Config) *logging.Logger {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 	format := logging.MustStringFormatter(config.LogFormat)
 	backendFormatter := logging.NewBackendFormatter(backend, format)

--- a/service/role_service.go
+++ b/service/role_service.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"database/sql"
-	"github.com/OscarYuen/go-graphql-starter/model"
-	"github.com/jmoiron/sqlx"
+
+	model "go-graphql-starter/model"
+
+	sqlx "github.com/jmoiron/sqlx"
 	"github.com/op/go-logging"
 )
 

--- a/service/user_service.go
+++ b/service/user_service.go
@@ -1,10 +1,13 @@
 package service
 
 import (
-	"database/sql"
 	"errors"
-	"github.com/OscarYuen/go-graphql-starter/context"
-	"github.com/OscarYuen/go-graphql-starter/model"
+
+	"database/sql"
+
+	gcontext "go-graphql-starter/context"
+	model "go-graphql-starter/model"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/op/go-logging"
 	"github.com/rs/xid"
@@ -99,10 +102,10 @@ func (u *UserService) Count() (int, error) {
 func (u *UserService) ComparePassword(userCredentials *model.UserCredentials) (*model.User, error) {
 	user, err := u.FindByEmail(userCredentials.Email)
 	if err != nil {
-		return nil, errors.New(context.UnauthorizedAccess)
+		return nil, errors.New(gcontext.UnauthorizedAccess)
 	}
 	if result := user.ComparePassword(userCredentials.Password); !result {
-		return nil, errors.New(context.UnauthorizedAccess)
+		return nil, errors.New(gcontext.UnauthorizedAccess)
 	}
 	return user, nil
 }


### PR DESCRIPTION
When cloning this repo and installing dependencies, the entire `OscarYuen/go-graphql-starter` is downloaded unnecessarily into _vendor_. By removing this dependency and having the project look for the packages locally, then changes can be gradually introduced and the project starter can be used to build as one cohesive project. Otherwise, it will be necessary to continually update the online repo and then pulling those changes to local vendor folder.

Build in Golang context can now be imported simply as `"context"`, the changes reflect this.

The dataloader package has been since included into graph-gophers and import reflects this as well.

I have run the graphiql and verified that setup with PostgresQL db works accordingly.

It is best to try out the changes before merging to master.

I hope this can better illustrate for new comers how to properly utilize the graph-gophers implementation in an updated version. Example applications can better serve if they reflect current versions.